### PR TITLE
Json encode twig variables

### DIFF
--- a/templates/query/common/aggs/attributes.json.twig
+++ b/templates/query/common/aggs/attributes.json.twig
@@ -29,7 +29,7 @@
                             },
                             "label": {
                                 "terms": {
-                                    "field": "attributes.name.{{localeCode}}"
+                                    "field": {{ ('attributes.name.' ~ localeCode)|json_encode|raw }}
                                 }
                             }
                         }

--- a/templates/query/common/aggs/options.json.twig
+++ b/templates/query/common/aggs/options.json.twig
@@ -34,7 +34,7 @@
                                         "aggs": {
                                             "label": {
                                                 "terms": {
-                                                    "field": "product-options.values.name.{{localeCode}}"
+                                                    "field": {{ ('product-options.values.name.' ~ localeCode)|json_encode|raw }}
                                                 }
                                             }
                                         }
@@ -43,7 +43,7 @@
                             },
                             "label": {
                                 "terms": {
-                                    "field": "product-options.name.{{localeCode}}"
+                                    "field": {{ ('product-options.name.' ~ localeCode)|json_encode|raw }}
                                 }
                             }
                         }

--- a/templates/query/common/aggs/translated-attributes.json.twig
+++ b/templates/query/common/aggs/translated-attributes.json.twig
@@ -24,12 +24,12 @@
                         "aggs": {
                             "values": {
                                 "terms": {
-                                    "field": "translated-attributes.values.{{ localeCode }}.values"
+                                    "field": {{ ('translated-attributes.values.' ~ localeCode ~ '.values')|json_encode|raw }}
                                 }
                             },
                             "label": {
                                 "terms": {
-                                    "field": "translated-attributes.name.{{localeCode}}"
+                                    "field": {{ ('translated-attributes.name.' ~ localeCode)|json_encode|raw }}
                                 }
                             }
                         }

--- a/templates/query/common/search/attribute.json.twig
+++ b/templates/query/common/search/attribute.json.twig
@@ -7,12 +7,12 @@
                     "filter": [
                         {
                             "term": {
-                                "attributes.code": "{{ filter.code }}"
+                                "attributes.code": {{ filter.code|json_encode|raw }}
                             }
                         },
                         {
                             "term": {
-                                "attributes.values.values": "{{ filter.value }}"
+                                "attributes.values.values": {{ filter.value|json_encode|raw }}
                             }
                         }
                     ]

--- a/templates/query/common/search/option.json.twig
+++ b/templates/query/common/search/option.json.twig
@@ -12,7 +12,7 @@
                         },
                         {
                             "term": {
-                                "variants.options.value.code": "{{ filter.value }}"
+                                "variants.options.value.code": {{ filter.value|json_encode|raw }}
                             }
                         }
                     ]

--- a/templates/query/common/search/translated-attribute.json.twig
+++ b/templates/query/common/search/translated-attribute.json.twig
@@ -7,12 +7,12 @@
                     "filter": [
                         {
                             "term": {
-                                "translated-attributes.code": "{{ filter.code }}"
+                                "translated-attributes.code": {{ filter.code|json_encode|raw }}
                             }
                         },
                         {
                             "term": {
-                                "translated-attributes.values.{{ localeCode }}.values": "{{ filter.value }}"
+                                {{ ('translated-attributes.values.' ~ localeCode ~ '.values')|json_encode|raw }}: {{ filter.value|json_encode|raw }}
                             }
                         }
                     ]

--- a/templates/query/common/sort/createdAt.json.twig
+++ b/templates/query/common/sort/createdAt.json.twig
@@ -1,5 +1,5 @@
 {
     "created-at": {
-        "order": "{{ order }}"
+        "order": {{ order|json_encode|raw }}
     }
 }

--- a/templates/query/common/sort/default.json.twig
+++ b/templates/query/common/sort/default.json.twig
@@ -1,5 +1,5 @@
 {
-    "{{ field }}": {
-        "order": "{{ order }}"
+    {{ field|json_encode|raw }}: {
+        "order": {{ order|json_encode|raw }}
     }
 }

--- a/templates/query/common/sort/name.json.twig
+++ b/templates/query/common/sort/name.json.twig
@@ -1,6 +1,6 @@
 {
-    "name-as-keyword.{{ localeCode }}": {
-        "order": "{{ order }}",
+    {{ ('name-as-keyword.' ~ localeCode)|json_encode|raw }}: {
+        "order": {{ order|json_encode|raw }},
         "nested": {
             "path": "name-as-keyword"
         }

--- a/templates/query/common/sort/position.json.twig
+++ b/templates/query/common/sort/position.json.twig
@@ -1,11 +1,11 @@
 {
     "taxons.position": {
-        "order": "{{ order }}",
+        "order": {{ order|json_encode|raw }},
         "nested": {
             "path": "taxons",
             "filter": {
                 "term": {
-                    "taxons.sylius-id": "{{ taxon.id }}"
+                    "taxons.sylius-id": {{ taxon.id|json_encode|raw }}
                 }
             }
         }

--- a/templates/query/common/sort/price.json.twig
+++ b/templates/query/common/sort/price.json.twig
@@ -1,5 +1,5 @@
 {
     "default-variant.price.price": {
-        "order": "{{ order }}"
+        "order": {{ order|json_encode|raw }}
     }
 }

--- a/templates/query/completion-suggesters/query.json.twig
+++ b/templates/query/completion-suggesters/query.json.twig
@@ -1,9 +1,9 @@
 {
     "suggest": {
-        "prefix": "{{ searchTerm }}",
+        "prefix": {{ searchTerm|json_encode|raw }},
         "completion": {
             "field": "suggest",
-            "size": {{ size }},
+            "size": {{ size|json_encode|raw }},
             "skip_duplicates": true,
             "fuzzy": {
                 "fuzziness": 1,

--- a/templates/query/search/query.json.twig
+++ b/templates/query/search/query.json.twig
@@ -1,3 +1,4 @@
+{% set searchTerm = searchTerm|json_encode %}
 {
     "bool": {
         "filter": [
@@ -15,7 +16,7 @@
         "should": [
             {
                 "term": {
-                    "code": "{{ searchTerm }}"
+                    "code": {{ searchTerm|raw }}
                 }
             },
             {
@@ -23,7 +24,7 @@
                     "path": "variants",
                     "query": {
                         "term": {
-                            "variants.code": "{{ searchTerm }}"
+                            "variants.code": {{ searchTerm|raw }}
                         }
                     }
                 }
@@ -33,8 +34,8 @@
                     "path": "name",
                     "query": {
                         "match": {
-                            "name.{{ localeCode }}": {
-                                "query": "{{ searchTerm }}",
+                            {{ ('name.' ~ localeCode)|json_encode|raw }}: {
+                                "query": {{ searchTerm|raw }},
                                 "boost": 10,
                                 "fuzziness": "AUTO",
                                 "fuzzy_transpositions": true,
@@ -49,8 +50,8 @@
                     "path": "variants",
                     "query": {
                         "match": {
-                            "variants.name.{{ localeCode }}": {
-                                "query": "{{ searchTerm }}",
+                            {{ ('variants.name.' ~ localeCode)|json_encode|raw }}: {
+                                "query": {{ searchTerm|raw }},
                                 "boost": 9,
                                 "fuzziness": "AUTO",
                                 "fuzzy_transpositions": true,
@@ -65,8 +66,8 @@
                     "path": "description",
                     "query": {
                         "match": {
-                            "description.{{ localeCode }}": {
-                                "query": "{{ searchTerm }}",
+                            {{ ('description.' ~ localeCode)|json_encode|raw }}: {
+                                "query": {{ searchTerm|raw }},
                                 "boost": 8,
                                 "fuzziness": "AUTO",
                                 "fuzzy_transpositions": true,
@@ -81,8 +82,8 @@
                     "path": "short-description",
                     "query": {
                         "match": {
-                            "short-description.{{ localeCode }}": {
-                                "query": "{{ searchTerm }}",
+                            {{ ('short-description.' ~ localeCode)|json_encode|raw }}: {
+                                "query": {{ searchTerm|raw }},
                                 "boost": 7,
                                 "fuzziness": "AUTO",
                                 "fuzzy_transpositions": true,
@@ -97,8 +98,8 @@
                     "path": "slug",
                     "query": {
                         "match": {
-                            "slug.{{ localeCode }}": {
-                                "query": "{{ searchTerm }}",
+                            {{ ('slug.' ~ localeCode)|json_encode|raw }}: {
+                                "query": {{ searchTerm|raw }},
                                 "boost": 6,
                                 "fuzziness": "AUTO",
                                 "fuzzy_transpositions": true,
@@ -113,8 +114,8 @@
                     "path": "meta-description",
                     "query": {
                         "match": {
-                            "meta-description.{{ localeCode }}": {
-                                "query": "{{ searchTerm }}",
+                            {{ ('meta-description.' ~ localeCode)|json_encode|raw }}: {
+                                "query": {{ searchTerm|raw }},
                                 "boost": 5,
                                 "fuzziness": "AUTO",
                                 "fuzzy_transpositions": true,
@@ -129,8 +130,8 @@
                     "path": "meta-keywords",
                     "query": {
                         "match": {
-                            "meta-keywords.{{ localeCode }}": {
-                                "query": "{{ searchTerm }}",
+                            {{ ('meta-keywords.' ~ localeCode)|json_encode|raw }}: {
+                                "query": {{ searchTerm|raw }},
                                 "boost": 4,
                                 "fuzziness": "AUTO",
                                 "fuzzy_transpositions": true,
@@ -145,8 +146,8 @@
                     "path": "taxons",
                     "query": {
                         "match": {
-                            "taxons.name.{{ localeCode }}": {
-                                "query": "{{ searchTerm }}",
+                            {{ ('taxons.name.' ~ localeCode)|json_encode|raw }}: {
+                                "query": {{ searchTerm|raw }},
                                 "boost": 3,
                                 "fuzziness": "AUTO",
                                 "fuzzy_transpositions": true,
@@ -161,8 +162,8 @@
                     "path": "translated-attributes",
                     "query": {
                         "match": {
-                            "translated-attributes.values.{{ localeCode }}.text-value": {
-                                "query": "{{ searchTerm }}",
+                            {{ ('translated-attributes.values.' ~ localeCode ~ '.text-value')|json_encode|raw }}: {
+                                "query": {{ searchTerm|raw }},
                                 "boost": 3,
                                 "fuzziness": "AUTO",
                                 "fuzzy_transpositions": true,
@@ -178,7 +179,7 @@
                     "query": {
                         "match": {
                             "attributes.values.text-value": {
-                                "query": "{{ searchTerm }}",
+                                "query": {{ searchTerm|raw }},
                                 "boost": 3,
                                 "fuzziness": "AUTO",
                                 "fuzzy_transpositions": true,
@@ -193,8 +194,8 @@
                     "path": "product-options",
                     "query": {
                         "match": {
-                            "product-options.values.name.{{ localeCode }}": {
-                                "query": "{{ searchTerm }}",
+                            {{ ('product-options.values.name.' ~ localeCode)|json_encode|raw }}: {
+                                "query": {{ searchTerm|raw }},
                                 "boost": 3,
                                 "fuzziness": "AUTO",
                                 "fuzzy_transpositions": true,

--- a/templates/query/taxon/query.json.twig
+++ b/templates/query/taxon/query.json.twig
@@ -14,7 +14,7 @@
                             "filter": [
                                 {
                                     "terms": {
-                                        "taxons.sylius-id": [{{ taxonIdsToSearch|join(', ') }}]
+                                        "taxons.sylius-id": {{ taxonIdsToSearch|json_encode|raw }}
                                     }
                                 }
                             ]

--- a/templates/query/term-suggesters/query.json.twig
+++ b/templates/query/term-suggesters/query.json.twig
@@ -1,8 +1,8 @@
 {
     "suggest": {
-        "text": "{{ searchTerm }}",
+        "text": {{ searchTerm|json_encode|raw }},
         "term": {
-            "field": "name.{{ localeCode }}",
+            "field": {{ ('name.' ~ localeCode)|json_encode|raw }},
             "suggest_mode" : "missing"
         }
     }


### PR DESCRIPTION
It's safer and better to use the json encoder for all variables that are passed to twig files