### PR TITLE
Fix taxon name path in query.json.twig

### DIFF
--- a/templates/query/search/query.json.twig
+++ b/templates/query/search/query.json.twig
@@ -182,7 +182,7 @@
                     "path": "product-taxons",
                     "query": {
                         "match": {
-                            {{ ('taxons.name.' ~ localeCode)|json_encode|raw }}: {
+                            {{ ('product-taxons.taxon.name.' ~ localeCode)|json_encode|raw }}: {
                                 "query": {{ searchTerm|raw }},
                                 "boost": {% block query_bool_should_product_taxon_names_boost %}3{% endblock %},
                                 "fuzziness": "AUTO",


### PR DESCRIPTION
`taxons.name.` does not work, the correct path is `product-taxons.taxon.name.`